### PR TITLE
Added `listen_on` configuration option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,18 @@ Install the binary and configuration file:
 - `go install github.com/nixprime/switchboard`. This builds a `bin/switchboard`
   somewhere in your $GOPATH, which you can move to wherever. (The included
   system startup scripts assume `switchboard` is located in `/usr/local/bin/`.)
+
 - Create `switchboard.conf` somewhere. Use the included `switchboard.conf` as a
   guide. (By default, Switchboard assumes that `switchboard.conf` is located in
   `/etc/`.)
+
+  Note that the default configuration instructs the daemon to listen
+  on port 80, the standard HTTP port (so your host should not be running some
+  other HTTP server), and to listen only on the `localhost` interface (so the
+  Switchboard service will not be accessible from other hosts). Change these
+  settings with the `port` and `listen_on` configuration file keys,
+  respectively. Setting `listen_on` to the empty string (`"listen_on": ""`)
+  will instruct the daemon to accept connections from any network.
 
 Enable the daemon to run as a non-root user:
 

--- a/switchboard.conf
+++ b/switchboard.conf
@@ -1,5 +1,6 @@
 {
   "port": 80,
+  "listen_on": "localhost",
   "hosts": {
     "m": {
       "": "https://mail.google.com/",

--- a/switchboard.go
+++ b/switchboard.go
@@ -144,15 +144,23 @@ func main() {
 	}
 	config := configBlob.(map[string]interface{})
 
-	// Select the port to listen on
+	// Select the TCP address (interface and port) to listen on
+	var listenOn string
 	var port uint16
+
+	listenOnConfigBlob, ok := config["listen_on"]
+	if ok {
+		listenOn = listenOnConfigBlob.(string)
+	} else {
+		listenOn = ""
+	}
 	portConfigBlob, ok := config["port"]
 	if ok {
 		port = uint16(portConfigBlob.(float64))
 	} else {
 		port = DefaultPort
 	}
-	portStr := strconv.FormatUint(uint64(port), 10)
+	listenAddr := listenOn + ":" + strconv.FormatUint(uint64(port), 10)
 
 	// Read the host map
 	hostBlob, ok := config["hosts"]
@@ -164,7 +172,7 @@ func main() {
 
 	// Start the server
 	http.HandleFunc("/", hostMap.HandleHost)
-	err = http.ListenAndServe(":"+portStr, nil)
+	err = http.ListenAndServe(listenAddr, nil)
 	if err != nil {
 		log.Fatalf("ListenAndServe: %s", err.Error())
 	}


### PR DESCRIPTION
The `listen_on` configuration option instructs the daemon to bind its
HTTP server to only a particular address/interface, so that, e.g., the
Switchboard service can be restricted to only `localhost`, or only a
local/internal network interface on a multihomed host.
